### PR TITLE
Allow for modal size to be specified via attribute on modal element

### DIFF
--- a/modal/index.html
+++ b/modal/index.html
@@ -1,7 +1,7 @@
 <index: arrays="action/actions" attributes="title" element="modal">
   <div class="modal fade{{if faded}} in{{/if}}" style="{{if show}}display: block{{/if}}">
     <div on-click="hide('backdrop')" class="modal-backdrop fade{{if faded}} in{{/if}}"></div>
-    <div class="modal-dialog">
+    <div class="modal-dialog{{if @size}} modal-{{@size}}{{/}}">
       <div class="modal-content">
         <div class="modal-header">
           <button on-click="hide('close')" type="button" class="close" aria-hidden="true">&times;</button>


### PR DESCRIPTION
Allows usage of the two optional sizes of regular bootstrap modals:
 http://getbootstrap.com/javascript/#modals