### PR TITLE
Bump bootstrap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/codeparty/d-bootstrap.git"
   },
   "dependencies": {
-    "bootstrap": "^3.3.1"
+    "bootstrap": "^3.3.5"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
From 3.3.1^ to 3.3.5^, which adds certain icons we need. Should be a no-brainer.
