### PR TITLE
[fix] Resolving path to css

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,5 +4,5 @@ module.exports = function(app, options) {
   app.component(require('./tabs'));
   app.component(require('./alert'));
   app.component(require('./contextMenu'));
-  if(!options || (options && options.loadStyles)) app.loadStyles(__dirname + '/node_modules/bootstrap/dist/css/bootstrap.min');
+  if(!options || (options && options.loadStyles)) app.loadStyles(require.resolve('bootstrap/dist/css/bootstrap.min.css'));
 };


### PR DESCRIPTION
With `require.resolve` this will work for both hierarchical `npm@2` and plain `npm@3` dependencies placement